### PR TITLE
Translations_04

### DIFF
--- a/Localisation/src/OCM_UI_LocalisationResources.en.json
+++ b/Localisation/src/OCM_UI_LocalisationResources.en.json
@@ -113,7 +113,9 @@
         "avaitingReview": "Awaiting Review",
         "recentActivity": "Recent Activity",
         "webApp": "Web App for Mobile",
-        "statistics": "Statistics"
+        "statistics": "Statistics",
+        "awaitingReviewImported": "Imported locations awaiting approval",
+        "editqueue": "Edits awaiting approval"
       },
       "develop": {
         "sectionTitle": "Develop",
@@ -171,11 +173,41 @@
         "webApp": "Web App",
         "searchAppStore": "especially on mobile devices. You can also search your device App Store for a version you can carry around."
       },
+      "sponsors": "We are seeking funding and sponsors, think you can help? {link:Find out more}.",
+      "disclaimer": "By using our services or submitting information to Open Charge Map you agree to our {link:standard terms, privacy policy and licensing}.",
       "about": {
+        "ourService": "Our Service",
+        "aimTitle": "Our Aim",
+        "aimContent": "Our aim is to work with the community to develop and provide a high quality, public, free, open database of charging equipment locations globally.",
+        "goalContent": "Our goal is to avoid the proliferation of independent conflicting charging location maps/websites/applications and to provide (as much as possible) a reliable single point of reference for charging equipment location information. Instead of competing with other data providers we aim to cooperate with and provide services to them, in exchange for data sharing and de-duplication efforts.",
+        "whyOCMTitle": "Why Use Open Charge Map?",
+        "whyOCMContent": "By using Open Charge Map and related apps you are helping to improve the information in the registry by providing peer review, edits, additions, comments, photos and by promoting the service to other users. The benefit of OCM over others providers is that OCM's purpose is to share information openly, whereas commercial providers have to keep their information to themselves (or within the confines of their own App etc.) in order to maintain a commercially marketable data set.",
         "funding": {
           "title": "Funding",
           "p1": "Open Charge Map is developed and operated by volunteers. If you can offer funding to support the project or to fund specific work please {link-contact:get in touch}. More information on funding and project costs {link-funding:is available}."
-        }
+        },
+        "steeringGroupTitle": "Steering Group",
+        "steeringGroupContent": "Our steering group consists of a wide range of people and organisations, both formally and informally:",
+        "coordinators": {
+          "sectionTitle": "Coordinators",
+          "content": "The following people provide leadership and coordination for the project:",
+          "christopher": "Christopher is the lead technical architect, database designer and lead developer for the Open Charge Map system. He is a director of the UK software development company {link_webprofusion:Webprofusion Ltd} and owner of {link_electriccarbuyer:electriccarbuyer.com}.",
+          "jC": "J-C is the community coordinator for the Open Charge Map project and an OCM Administrator, promoting the uptake of OCM by the public and industry. Links: {link_twitter:Twitter}, {link_google_plus:Google+} and {link_website:Website}.",
+          "kevin": "Kevin started the original Open Charge Map initiative. He is also the founder and chairman of the UK carbon reduction charity {link:Zero Carbon World} who sponsor the server hosting of Open Charge Map."
+        },
+        "developersContributors": {
+          "sectionTitle": "Developers and Contributors",
+          "p1": "Our {link_github:GitHub project} provides a conduit for external technical contributors to discuss and influence our system and plans. Our {link_google_plus:Google+} community is our primary means of exchanging ideas and gathering feedback from interested parties.",
+          "p2": "You can take a look at the lists of our main contributors of {link_code:code}, {link_translations:translations} and {link_data:data}."
+        },
+        "projectStats": {
+          "sectionTitle": "Project Stats",
+          "general": "General statistics for Open Charge Map {link:data and usage} are available.",
+          "devCosts": "The following is an estimation of the software development costs, if someone were to develop an equivalent project commercially:"
+        },
+        "dataSourcesTitle": "Data Sources",
+        "dataSourcesContent": "The data made available through the Open Charge Map system and related services is sourced from many locations and is often provided directly (\"crowd sourced\") by our users and those of apps using our services.",
+        "dataSourcesThanks": "Credit and our thanks goes to following major data sources currently included in our database:"
       }
     },
     "reference": {

--- a/Localisation/src/OCM_UI_LocalisationResources.sk.json
+++ b/Localisation/src/OCM_UI_LocalisationResources.sk.json
@@ -113,7 +113,9 @@
         "avaitingReview": "Nepotvrdené umiestnenia",
         "recentActivity": "Nedávnu činnosť",
         "webApp": "Mobilnú aplikáciu",
-        "statistics": "Štatistiky"
+        "statistics": "Štatistiky",
+        "awaitingReviewImported": "Importované umiestnenia čakajúce na schválenie",
+        "editqueue": "Úpravy čakajúce na schválenie"
       },
       "develop": {
         "sectionTitle": "Vývoj",
@@ -171,11 +173,42 @@
         "webApp": "webovú aplikáciu",
         "searchAppStore": "hlavne na mobilných zariadeniach. V obchode s aplikáciami na Vašom zariadení nájdete aj verziu, ktorú môžete mať stále so sebou."
       },
+      "sponsors": "Hľadáme sponzorov. Vieš s tým pomôcť? {link:Zisti viac}.",
+      "disclaimer": "Používaním našich služieb alebo pridaním informácii do databázy Open Charge Map súhlasíte s našimi {link:všeobecnými podmienkami, politikou ochrany súkromia a licencovaním}.",
       "about": {
+        "ourService": "Naša služba",
+        "aimTitle": "Naše ciele",
+        "aimContent": "Chceme spolupracovať s komunitou na vytváraní a poskytovaní vysoko kvalitnej, otvorenej, verejnej a bezplatnej databáze nabíjacích zariadení po celom svete.",
+        "goalContent": "Naším cieľom je tiež zabrániť potrebe šírenia nezávislých konfliktných máp/stránok/aplikácii poskytovaním jedného spoľahlivého (v maximálnej možnej miere) zdroja informácií o nabíjacích staniciach. Namiesto súťaženia s inými poskytovateľmi dát sa snažíme s nimi spolupracovať a ponúkať im služby výmenou za zdieľanie ich dát a snahu o neduplikovanie informácií.",
+        "whyOCMTitle": "Prečo používať Open Charge Map?",
+        "whyOCMContent": "Používaním Open Charge Map (OCM) a príslušných aplikácii môžete pomôcť vylepšiť informácie v databáze recenziami, zmenami a pridávaním informácií, komentárov a fotiek a odporúčaním služby ostatným užívateľom. Výhodou OCM oproti ostatným poskytovateľom podobných dát je, že cieľom OCM je otvorené zdieľanie informácií, kým komerční poskytovatelia si musia ponechávať informácie pre seba (alebo len vrámci svojej aplikácie), aby si mohli udržovať komerčne speňažiteľné množstvo dát.",
         "funding": {
-          "title": null,
-          "p1": null
-        }
+          "title": "Financovanie",
+          "p1": "Open Charge Map je vyvinutá a udržovaná dobrovoľníkmi. Ak môžete ponúknuť financovanie na podporu projektu alebo podporiť konkrétnu pracovnú činnosť prosím {link-contact:kontaktujte nás}. Viac informácií ohľadom financovania a projektových nákladov {link-funding:je k dispozícií}."
+        },
+        "steeringGroupTitle": "Riadiaci výbor",
+        "steeringGroupContent": "Náš riadiaci výbor pozostáva zo širokého spektra ľudí a organizácii, ako formálne, tak i neformálne:",
+        "coordinators": {
+          "sectionTitle": "Koordinátori",
+          "content": "Nasledujúci ľudia zaisťujú vedenie a koordináciu projektu:",
+          "christopher": "Christopher je vedúci technický architekt, dizajnér databázy a vedúci vývojár systému Open Charge Map. Je riaditeľ anglickej softvérovej firmy {link_webprofusion:Webprofusion Ltd} a vlastník {link_electriccarbuyer:electriccarbuyer.com}.",
+          "jCGeneral": "J-C je komunitný koordinátor a administrátor projektu, podporujúci prijatie Open Charge Map verejnosťou a odvetvím. Odkazy",
+          "jC": "J-C je komunitný koordinátor a administrátor projektu, podporujúci prijatie Open Charge Map verejnosťou a odvetvím. Odkazy: {link_twitter:Twitter}, {link_google_plus:Google+} and {link_website:webová stránka}.",
+          "kevin": "Kevin začal pôvodnú verziu projektu Open Charge Map. Je tiež zakladateľom a predsedom anglickej charitatívnej organizácie podporujúcej zníženie uhlíkovej stopy pod názvom {link:Zero Carbon World} ktorá sponzoruje server hosting pre Open Charge Map."
+        },
+        "developersContributors": {
+          "sectionTitle": "Vývojári a prispievatelia",
+          "p1": "Náš projekt na {link_github:GitHube} poskytuje zázemie, ktoré umožnuje externým technickým prispievateľom diskutovať a ovlpyvniť náš systém a plány do budúcnosti. Naša komunita na {link_google_plus:Google+} je hlavný spôsob výmeny nápadov a získavania spätnej väzby od zainteresovaných strán.",
+          "p2": "Môžete si prezrieť zoznamy našich najvačších prispievateľov {link_code:kódu}, {link_translations:prekladov} a {link_data:dát}."
+        },
+        "projectStats": {
+          "sectionTitle": "Projektové štatistiky",
+          "general": "Máme k dispozícií všeobecné štatistiky ohľadom {link:dát a používanosti} Open Charge Map.",
+          "devCosts": "Nasleduje odhad ceny vývoja softvéru v prípade, že by sa niekto snažil vyvinúť ekvivalentný projekt komerčne:"
+        },
+        "dataSourcesTitle": "Zdroje dát",
+        "dataSourcesContent": "Dáta, ktoré sú k dispozícií prostredníctvom systému Open Charge Map a príslušných služieb sa získavajú z mnohých zdrojov a sú často získavané priamo prostredníctvom \"crowdsourcingu\", teda pridané našimi užívateľmi a aplikáciami používajúcimi naše služby.",
+        "dataSourcesThanks": "Uznanie a vďaka patrí nasledujúcim hlavným zdrojom dát, ktoré sú v súčasnosti zahrnuté v našej databáze:"
       }
     },
     "reference": {

--- a/Website/OCM.MVC/Views/About/Index.cshtml
+++ b/Website/OCM.MVC/Views/About/Index.cshtml
@@ -1,20 +1,20 @@
 ﻿@{
     ViewBag.Title = "About Open Charge Map";
 }
-<h2>Our Service</h2>
-<p>Open Charge Map is a non-commercial, non-profit, electric vehicle data service hosted and supported by a community of businesses, charities, developers and interested parties around the world.</p>
+<h2 data-localize="ocm.infoText.about.ourService">Our Service</h2>
+<p data-localize="ocm.infoText.shortProjectSummary">Open Charge Map is a non-commercial, non-profit, electric vehicle data service hosted and supported by a community of businesses, charities, developers and interested parties around the world.</p>
 @Html.Partial("_TermsLink")
 
-<h2>Our Aim</h2>
-<p>Our aim is to work with the community to develop and provide a high quality, public, free, open database of charging equipment locations globally.</p>
-<p>
+<h2 data-localize="ocm.infoText.about.aimTitle">Our Aim</h2>
+<p data-localize="ocm.infoText.about.aimContent">Our aim is to work with the community to develop and provide a high quality, public, free, open database of charging equipment locations globally.</p>
+<p data-localize="ocm.infoText.about.goalContent">
     Our goal is to avoid the proliferation of independent conflicting charging location maps/websites/applications
     and to provide (as much as possible) a reliable single point of reference for charging equipment location information.
     Instead of competing with other data providers we aim to cooperate with and provide services to them, in exchange for
     data sharing and de-duplication efforts.
 </p>
-<h2>Why Use Open Charge Map?</h2>
-<p>By using Open Charge Map and related apps you are helping to improve the information in the registry by providing peer review, edits, additions, comments, photos and by promoting the service to other users. The benefit of OCM over others providers is that OCM's purpose is to share information openly, whereas commercial providers have to keep their information to themselves (or within the confines of their own App etc.) in order to maintain a commercially marketable data set.</p>
+<h2 data-localize="ocm.infoText.about.whyOCMTitle">Why Use Open Charge Map?</h2>
+<p data-localize="ocm.infoText.about.whyOCMContent">By using Open Charge Map and related apps you are helping to improve the information in the registry by providing peer review, edits, additions, comments, photos and by promoting the service to other users. The benefit of OCM over others providers is that OCM's purpose is to share information openly, whereas commercial providers have to keep their information to themselves (or within the confines of their own App etc.) in order to maintain a commercially marketable data set.</p>
 
 <div>
     <h2 data-localize="ocm.infoText.about.funding.title">Funding</h2>
@@ -23,42 +23,59 @@
 
 <div class="row">
     <div class="col-md-6">
-        <h2>Steering Group</h2>
+        <h2 data-localize="ocm.infoText.about.steeringGroupTitle">Steering Group</h2>
 
-        <p>
+        <p data-localize="ocm.infoText.about.steeringGroupContent">
             Our steering group consists of a wide range of people and organisations, both formally and informally:
         </p>
-        <h3>Coordinators</h3>
-        <p>
+        <h3 data-localize="ocm.infoText.about.coordinators.sectionTitle">Coordinators</h3>
+        <p data-localize="ocm.infoText.about.coordinators.content">
             The following people provide leadership and coordination for the project:
         </p>
 
         <h4>Christopher Cook</h4>
-        <p>Christopher is the lead technical architect, database designer and lead developer for the Open Charge Map system. He is a director of the UK software development company Webprofusion Ltd (<a href="http://www.webprofusion.com">www.webprofusion.com</a>) and owner of <a href="http://www.electriccarbuyer.com">electriccarbuyer.com</a></p>
+        <p data-localize="ocm.infoText.about.coordinators.christopher">Christopher is the lead technical architect, database designer and lead developer for the Open Charge Map system. He is a director of the UK software development company <a href="http://www.webprofusion.com" data-localize-id="link_webprofusion">Webprofusion Ltd</a> and owner of <a href="http://www.electriccarbuyer.com" data-localize-id="link_electriccarbuyer">electriccarbuyer.com</a>.</p>
+<!--         <p>
+          <p data-localize="ocm.infoText.sponsors">We are seeking funding and sponsors, think you can help? <a href="@Url.Action("Funding","About")" data-localize-id="link">Find out more</a>.</p>
+            <span data-localize="ocm.infoText.about.coordinators.christopherGeneral">Christopher is the lead technical architect, database designer and lead developer for the Open Charge Map system. He is a director of the UK software development company Webprofusion Ltd </span>
+            (<a href="http://www.webprofusion.com">www.webprofusion.com</a>)
+            <span data-localize="ocm.infoText.aboutUs.coordinators.christopherOwner">and owner of</span>
+            <a href="http://www.electriccarbuyer.com">electriccarbuyer.com</a>.
+        </p> -->
         <h4>Jean-Christoph Saint-Pô</h4>
-        <p>J-C is the community coordinator for the Open Charge Map project and an OCM Administrator, promoting the uptake of OCM by the public and industry. Links: <a href="https://twitter.com/jcstp">Twitter</a>, <a href="https://plus.google.com/u/0/115943172884477844202/">Google+</a>, <a href="http://home.scarlet.be/jcsaintpo/">Website</a></p>
+        <p data-localize="ocm.infoText.about.coordinators.jC">J-C is the community coordinator for the Open Charge Map project and an OCM Administrator, promoting the uptake of OCM by the public and industry. Links: <a href="https://twitter.com/jcstp" data-localize-id="link_twitter">Twitter</a>, <a href="https://plus.google.com/u/0/115943172884477844202/" data-localize-id="link_google_plus">Google+</a>, <a href="http://home.scarlet.be/jcsaintpo/" data-localize-id="link_website">Website</a>.</p>
         <h4>Kevin Sharpe</h4>
-        <p>
-            Kevin started the original Open Charge Map initiative. He is also the founder and chairman of the UK carbon reduction charity Zero Carbon World (<a href="http://www.zerocarbonworld.org">www.zerocarbonworld.org</a>) who sponsor the server hosting of Open Charge Map.
+        <p data-localize="ocm.infoText.about.coordinators.kevin">
+            Kevin started the original Open Charge Map initiative. He is also the founder and chairman of the UK carbon reduction charity Zero Carbon World (<a href="http://www.zerocarbonworld.org" data-localize-id="link">www.zerocarbonworld.org</a>) who sponsor the server hosting of Open Charge Map.
         </p>
     </div>
     <div class="col-md-6">
-        <h2>Developers and Contributors</h2>
-        <p>Our <a href="https://github.com/openchargemap">GitHub project</a> provides a conduit for external technical contributors to discuss and influence our system and plans. Our <a href="https://plus.google.com/u/0/communities/112113799071360649945">google+</a> community is our primary means of exchanging ideas and gathering feedback from interested parties.</p>
-        <p>Our list of main code contributors is here: <a href="https://github.com/openchargemap/ocm-system/graphs/contributors">https://github.com/openchargemap/ocm-system/graphs/contributors</a></p>
-        <p>Our list of UI translation contributors is here: <a href="https://webtranslateit.com/en/projects/6978-Open-Charge-Map/peoples">Contributors on WebTranslateIt</a></p>
-        <p>Our list of top data editors/contributors is here: <a href="@Url.Action("Index","Stats")">Data Contributors/Editors</a></p>
-        <h2>Project Stats</h2>
-        <p>General statistics for Open Charge Map <a href="@Url.Action("Index","Stats")">data and usage</a> are available.</p>
-        <p>The following is an estimation of the software development costs, if someone were to develop an equivalent project commercially: </p>
+        <h2 data-localize="ocm.infoText.about.developersContributors.sectionTitle">Developers and Contributors</h2>
+        <p data-localize="ocm.infoText.about.developersContributors.p1">Our <a href="https://github.com/openchargemap" data-localize-id="link_github">GitHub project</a> provides a conduit for external technical contributors to discuss and influence our system and plans. Our <a href="https://plus.google.com/u/0/communities/112113799071360649945" data-localize-id="link_google_plus">google+</a> community is our primary means of exchanging ideas and gathering feedback from interested parties.</p>
+        <p data-localize="ocm.infoText.about.developersContributors.p2">
+            You can take a look at the lists of our main contributors of
+            <a href="https://github.com/openchargemap/ocm-system/graphs/contributors" data-localize-id="link_code">code</a>,
+            <a href="https://webtranslateit.com/en/projects/6978-Open-Charge-Map/people" data-localize-id="link_translations">translations</a>
+            and
+            <a href="@Url.Action("Index","Stats")" data-localize-id="link_data">data</a>.
+        </p>
+        <h2 data-localize="ocm.infoText.about.projectStats.sectionTitle">Project Stats</h2>
+        <!-- <p>General statistics for Open Charge Map <a href="@Url.Action("Index","Stats")">data and usage</a> are available.</p> -->
+        <p data-localize="ocm.infoText.about.projectStats.general">General statistics for Open Charge Map <a href="@Url.Action("Index","Stats")" data-localize-id="link">data and usage</a> are available.</p>
+<!--         <p>
+            <span data-localize="ocm.infoText.aboutUs.projectStats.general">General statistics for Open Charge Map</span>
+            <a href="@Url.Action("Index","Stats")" data-localize="ocm.infoText.aboutUs.projectStats.link">data and usage</a>
+            <span data-localize="ocm.infoText.aboutUs.projectStats.generalContinued">are available</span>.
+        </p> -->
+        <p data-localize="ocm.infoText.about.projectStats.devCosts">The following is an estimation of the software development costs, if someone were to develop an equivalent project commercially: </p>
         <script type="text/javascript" src="http://www.ohloh.net/p/605311/widgets/project_cocomo.js"></script>
     </div>
 </div>
-<h2>Data Sources</h2>
-<p>
+<h2 data-localize="ocm.infoText.about.dataSourcesTitle">Data Sources</h2>
+<p data-localize="ocm.infoText.about.dataSourcesContent">
     The data made available through the Open Charge Map system and related services is sourced from many locations and is often provided directly ("crowd sourced") by our users and those of apps using our services.
 </p>
-<p>Credit and our thanks goes to following major data sources currently included in our database:</p>
+<p data-localize="ocm.infoText.about.dataSourcesThanks">Credit and our thanks goes to following major data sources currently included in our database:</p>
 @{
     var providers = (List<OCM.API.Common.Model.DataProvider>)new OCM.API.Common.ReferenceDataManager().GetCoreReferenceData().DataProviders;
 }

--- a/Website/OCM.MVC/Views/Shared/_Layout.cshtml
+++ b/Website/OCM.MVC/Views/Shared/_Layout.cshtml
@@ -107,7 +107,7 @@
                             <li><a href="@Url.Action("Index", "About")" data-localize="ocm.general.about">about</a></li>
                             <li><a href="@Url.Action("Terms", "About")" data-localize="ocm.navigation.about.termsPrivacy">terms &amp; privacy</a></li>
                             <li><a href="@Url.Action("Guidance", "About")" data-localize="ocm.navigation.about.guidance">guidance for contributors</a></li>
-                            <li><a href="@Url.Action("Funding", "About")" data-localize="ocm.navigation.about.funding">funding</a></li>
+                            <li><a href="@Url.Action("Funding", "About")" data-localize="ocm.infoText.about.funding.title">funding</a></li>
                             <li><a href="@Url.Action("Contact", "About")" data-localize="ocm.navigation.about.contact">contact</a></li>
                         </ul>
                     </li>
@@ -191,7 +191,7 @@
                     <h3>Open Charge Map <small data-localize="ocm.general.shortDescription">the global public registry of electric vehicle charging locations</small></h3>
 
                     <div id="datasummary"></div>
-                    <p data-localize="ocm.infoText.funding">We are seeking funding and sponsors, think you can help? <a href="@Url.Action("Funding","About")" data-localize-linkid="link">Find out more</a>.</p>
+                    <p data-localize="ocm.infoText.sponsors">We are seeking funding and sponsors, think you can help? <a href="@Url.Action("Funding","About")" data-localize-id="link">Find out more</a>.</p>
                     <p class="pull-right">
                         <a class="btn btn-info btn-sm" href="@Url.Action("Index", "POI")"><span class="glyphicon glyphicon-search"></span> <span data-localize="ocm.general.linkBrowsePOI">Browse All Locations</span></a>
                         <a class="btn btn-warning btn-sm" href="@Url.Action("Add", "POI")"><span class="glyphicon glyphicon-plus-sign"></span> <span data-localize="ocm.general.addLocation">Add A Location</span></a>

--- a/Website/OCM.MVC/Views/Shared/_TermsLink.cshtml
+++ b/Website/OCM.MVC/Views/Shared/_TermsLink.cshtml
@@ -1,2 +1,4 @@
 ﻿
-<p class="alert alert-info">By using our services or submitting information to Open Charge Map you agree to our <a target="_blank" class="alert-link" href="@Url.Action("Terms","About")">standard terms, privacy policy and licensing.</a></p>
+<p class="alert alert-info">
+    <span data-localize="ocm.infoText.disclaimer">By using our services or submitting information to Open Charge Map you agree to our <a target="_blank" class="alert-link" href="@Url.Action("Terms","About")" data-localize-id="link">standard terms, privacy policy and licensing</a>.
+</p>


### PR DESCRIPTION
Made the "About" page and few other terms (3 new items in the menu and 1
on the main page) translatable. This commit contains basically same
changes as the "Translations 03" commit, but with the updated
translation environment (so the handling of resource keys is different).