### PR TITLE
Update ImportProvider_AFDC.cs

### DIFF
--- a/Import/OCM.Import.Common/Providers/ImportProvider_AFDC.cs
+++ b/Import/OCM.Import.Common/Providers/ImportProvider_AFDC.cs
@@ -218,6 +218,11 @@ namespace OCM.Import.Providers
 
                         if (evconnectors.Any(c => c.Value<string>() == "J1772")) cinfo.ConnectionTypeID = 1; //J1772
 
+                        if (evconnectors.Any(c => c.Value<string>() == "TESLA"))
+                        {
+                            cinfo.ConnectionTypeID = 30; //tesla model S North America proprietary
+                        }
+                       
                         if (cinfo.ConnectionTypeID == 0 && evconnectors.Any())
                         {
                             //unknown connection type


### PR DESCRIPTION
Cater for North American style Tesla proprietary connectors for Level 2, as used for Tesla Destination Charging in the USA, at the moment they're importing from AFDC as unknown connector type.