### PR TITLE
Update ImportProvider_UKChargePointRegistry.cs

### DIFF
--- a/Import/OCM.Import.Common/Providers/ImportProvider_UKChargePointRegistry.cs
+++ b/Import/OCM.Import.Common/Providers/ImportProvider_UKChargePointRegistry.cs
@@ -325,11 +325,11 @@ namespace OCM.Import.Providers
                         if (cp.Connections == null)
                         {
                             cp.Connections = new List<ConnectionInfo>();
-                            if (!IsConnectionInfoBlank(cinfo))
-                            {
-                                //TODO: skip items with blank address info
-                                cp.Connections.Add(cinfo);
-                            }
+                        } 
+                        if (!IsConnectionInfoBlank(cinfo))
+                        {
+                            //TODO: skip items with blank address info
+                            cp.Connections.Add(cinfo);
                         }
                     }
                 }


### PR DESCRIPTION
If the connections List has already been defined, we're onto our second (or later) connection from the import for this device, we should still add the connector to the list.

There may be a nicer way of doing this, by aggregating connectors by type and power, and actually updating the quantity field. but at least this way we get a record that a device has multiple connectors, which previously was lost, and in some cases, a rapid charger capable of 50kW DC charging was defined as just a 22kW AC charger because that was first in the list.