### PR TITLE
Fix geospacial queries to use the MongoDB index

### DIFF
--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -1156,7 +1156,7 @@ namespace OCM.Core.Data
                     }
                     else
                     {
-                        if (filter.BoundingBox != null && filter.BoundingBox.Any()) {
+                        if (filter.BoundingBox == null || !filter.BoundingBox.Any()) {
                             poiList = poiList.OrderByDescending(p => p.ID);
                         }
                         // In boundingbox more, if no sorting was requested by the user,

--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -1156,7 +1156,12 @@ namespace OCM.Core.Data
                     }
                     else
                     {
-                        results = poiList.OrderByDescending(p => p.ID).Take(filter.MaxResults).AsEnumerable();
+                        if (filter.BoundingBox != null && filter.BoundingBox.Any()) {
+                            poiList = poiList.OrderByDescending(p => p.ID);
+                        }
+                        // In boundingbox more, if no sorting was requested by the user,
+                        // do not perform any sorting for performance reasons.
+                        results = poiList.Take(filter.MaxResults).AsEnumerable();
                     }
 
                     System.Diagnostics.Debug.Print($"MongoDB finished query to list @ {stopwatch.ElapsedMilliseconds}ms");


### PR DESCRIPTION
Resolves #170 

## TOC

1. Use the geospatial "2d" index for boundingbox queries
2. Do not sort the result set when doing boundingbox queries for performance reasons

## TL;DR

This changes the existing MongoDB geospatial index in "2d" and rework the query logic to use that.

Prior to this PR MongoDB was not able to use the geospatial index when doing boundingbox queries and this lead to a major performance degradation and high RAM usage on the MongoDB server instance. See #170 for details.

### Technical Stuff

MongoDB uses the `2dsphere` index only for queries with the `$geometry` operator, see https://docs.mongodb.com/manual/tutorial/query-a-2dsphere-index/. For "basic" `$polygon` queries only the legacy `2d` index can be used.

To leverage the `2dsphere` index a newer version of the MongoDB Library has to be used. The legacy version of the MongoDB driver (1.x) (currently used throughout the codebase) can not do that, unfortunately.

### Benchmarks

On my local machine the query time for a boundingbox query went down from ~400ms to ~30ms. Using the index the mongo instance runs also fine with 512MB RAM in docker.

### Sorting Behavior Change

Additionally this change also skips the sorting of the result set by ID when doing boundingbox queries to get even more performance. This is especially a thing when dealing with large result sets, e.v. 500 records or more.