### PR TITLE
Implement a poi/count endpoint

### DIFF
--- a/API/OCM.Net/OCM.API.Core/Common/POIManager.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/POIManager.cs
@@ -581,6 +581,22 @@ namespace OCM.API.Common
         }
 
         /// <summary>
+        /// For given query/output settings, return just the charge point count. May be a cached response.
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public async Task<int?> GetPOICountAsync(APIRequestParams filterParams) {
+            // clone filter settings to remove mutation side effects in callers
+            var filter = JsonConvert.DeserializeObject<APIRequestParams>(JsonConvert.SerializeObject(filterParams));
+            filter.EnableCaching = false;
+
+            if (!filter.AllowMirrorDB) {
+                throw new Exception("not implemented");
+            }
+            return await CacheProviderMongoDB.DefaultInstance.GetPOICountAsync(filter);
+        }
+
+        /// <summary>
         /// for given charge point, return list of similar charge points based on location/title etc with approx similarity
         /// </summary>
         /// <param name="poi"></param>

--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -904,7 +904,7 @@ namespace OCM.Core.Data
             return GetPOIListAsync(settings).Result;
         }
 
-        protected IQueryable<OCM.API.Common.Model.ChargePoint> applyPOIFilterCriteria(
+        protected IQueryable<OCM.API.Common.Model.ChargePoint> ApplyPOIFilterCriteria(
             IQueryable<OCM.API.Common.Model.ChargePoint> poiList,
             APIRequestParams filter)
         {
@@ -1116,7 +1116,7 @@ namespace OCM.Core.Data
                     }
                 }
 
-                poiList = applyPOIFilterCriteria(poiList, filter);
+                poiList = ApplyPOIFilterCriteria(poiList, filter);
 
                 if (filter.ChangesFromDate != null)
                 {
@@ -1294,7 +1294,7 @@ namespace OCM.Core.Data
             IQueryable<OCM.API.Common.Model.ChargePoint> poiList = from c in collection.AsQueryable<OCM.API.Common.Model.ChargePoint>() select c;
             poiList = poiList.Where(q => Query.WithinPolygon("SpatialPosition.coordinates", pointList).Inject());
 
-            poiList = applyPOIFilterCriteria(poiList, filter);
+            poiList = ApplyPOIFilterCriteria(poiList, filter);
 
             return poiList.Count();
         }

--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -1040,6 +1040,10 @@ namespace OCM.Core.Data
                 searchPolygon = filter.Polygon;
             }
 
+            if (searchPolygon == null) {
+                return null;
+            }
+
             pointList = new double[searchPolygon.Count(), 2];
             int pointIndex = 0;
             foreach (var p in searchPolygon)
@@ -1271,7 +1275,10 @@ namespace OCM.Core.Data
             var collection = database.GetCollection<OCM.API.Common.Model.ChargePoint>("poi");
             IQueryable<OCM.API.Common.Model.ChargePoint> poiList = from c in collection.AsQueryable<OCM.API.Common.Model.ChargePoint>() select c;
             var pointList = BuildGeoWithinPolygon(filter);
-            poiList = poiList.Where(q => Query.WithinPolygon("SpatialPosition.coordinates", pointList).Inject());
+
+            if (pointList != null) {
+                poiList = poiList.Where(q => Query.WithinPolygon("SpatialPosition.coordinates", pointList).Inject());
+            }
 
             poiList = ApplyPOIFilterCriteria(poiList, filter);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  db:
+    image: mongo:4.2
+    command: mongod --profile=1 --slowms=1
+    ports:
+      - 27017:27017


### PR DESCRIPTION
## Rationale

Sometimes it is desirable to get just the number of items for specific filter criteria and not the data itself. For example, when trying to figure out the density/coverage for a specific area and decide how to render the data and/or to switch UI modes etc.

## Description

This PR introduces a new API Endpoint `/poi/count` for this purpose. This Endpoint will accept all filter criteria as the regular `/poi` endpoint but will return just the count of matching records, e.g.:

`GET /api/poi/count?boundingbox=(48.8,9.1),(48.7,9.2)`:

```json
{"count":102}
```

### Performance Consideration

When not using any filter criteria, the underlying MongoDB Query can use the 2d index directly and this will also deliver best performance. When using large bounding rects and filter criteria, the server has to perform a colscan to calculate the count of matching records which can take some time.

This can be improved later on by using a compound index.

## Outlook

A more flexible option will be to implement a real clustering algorithm, e.g. using a pre-calculated geo-hash field for various levels, getting the separate buckets with their middle coordinates and the count.