### PR TITLE
Update ConnectionInfo.cshtml

### DIFF
--- a/Website/OCM.Web/Views/Shared/EditorTemplates/ConnectionInfo.cshtml
+++ b/Website/OCM.Web/Views/Shared/EditorTemplates/ConnectionInfo.cshtml
@@ -99,7 +99,7 @@
         </div>
     </div>
     <div class="col-sm-4">
-        <div class="form-group" data-editormode="advanced">
+        <div class="form-group" data-editormode="core">
             <div>
                 @Html.LabelFor(model => model.Reference)
             </div>


### PR DESCRIPTION
Given that the Reference field is now being displayed and populated by the new map's editor, it's only sensible that this field is displayed for editors to check on.