### PR TITLE
Update ConnectionInfo.cshtml

### DIFF
--- a/Website/OCM.Web/Views/Shared/EditorTemplates/ConnectionInfo.cshtml
+++ b/Website/OCM.Web/Views/Shared/EditorTemplates/ConnectionInfo.cshtml
@@ -113,7 +113,7 @@
 </div>
 
 
-<div class="form-group" data-editormode="extended">
+<div class="form-group" data-editormode="core">
     <div>
         @Html.LabelFor(model => model.Comments)
     </div>


### PR DESCRIPTION
The Comments field for the connector is also exposed and editable via the new map-based editor, so again, it makes sense if editors get to see this when editing.