### PR TITLE
Fix Boundingbox Query Index Type

### DIFF
--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -423,7 +423,7 @@ namespace OCM.Core.Data
         protected void EnsureMongoDBIndexes()
         {
             var poiCollection = database.GetCollection<POIMongoDB>("poi");
-            poiCollection.CreateIndex(IndexKeys.GeoSpatialSpherical("SpatialPosition.coordinates")); // bounding box queries
+            poiCollection.CreateIndex(IndexKeys.GeoSpatial("SpatialPosition.coordinates")); // bounding box queries
             poiCollection.CreateIndex(IndexKeys<POIMongoDB>.GeoSpatialSpherical(x => x.SpatialPosition)); // distance queries
             poiCollection.CreateIndex(IndexKeys<POIMongoDB>.Descending(x => x.DateLastStatusUpdate));
             poiCollection.CreateIndex(IndexKeys<POIMongoDB>.Descending(x => x.DateCreated));


### PR DESCRIPTION
This fixes a regression caused by bc61dca9ec400ecabf049462429f791eff447530.

See https://github.com/openchargemap/ocm-system/issues/170 and related for details. 

## In a nutshell

bc61dca9ec400ecabf049462429f791eff447530 changes the index type to be a "2dsphere" but this will not be used at all for the bounding box queries currently generated by the app logic.