### PR TITLE
Extend POI search with media, comment, and check-in filters

### DIFF
--- a/API/OCM.Net/OCM.API.Core/Common/POIManager.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/POIManager.cs
@@ -344,6 +344,42 @@ namespace OCM.API.Common
                 poiList = poiList.Where(c => c.ConnectionInfos.Any(conn => conn.LevelTypeId != null && filter.LevelIDs.Contains((int)conn.LevelTypeId)));
             }
 
+            if (filter.HasMedia != null)
+            {
+                if (filter.HasMedia == true)
+                {
+                    poiList = poiList.Where(c => c.MediaItems.Any(m => m.IsEnabled == true));
+                }
+                else
+                {
+                    poiList = poiList.Where(c => !c.MediaItems.Any(m => m.IsEnabled == true));
+                }
+            }
+
+            if (filter.HasComment != null)
+            {
+                if (filter.HasComment == true)
+                {
+                    poiList = poiList.Where(c => c.UserComments.Any());
+                }
+                else
+                {
+                    poiList = poiList.Where(c => !c.UserComments.Any());
+                }
+            }
+
+            if (filter.HasCheckins != null)
+            {
+                if (filter.HasCheckins == true)
+                {
+                    poiList = poiList.Where(c => c.UserComments.Any(comment => comment.CheckinStatusTypeId != null));
+                }
+                else
+                {
+                    poiList = poiList.Where(c => !c.UserComments.Any(comment => comment.CheckinStatusTypeId != null));
+                }
+            }
+
             poiList = poiList.Where(c => c.AddressInfo != null);
             return poiList;
         }

--- a/API/OCM.Net/OCM.API.Core/Common/SearchFilterSettings.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/SearchFilterSettings.cs
@@ -90,7 +90,9 @@ namespace OCM.API.Common
 
         public double? MinPowerKW { get; set; }
         public double? MaxPowerKW { get; set; }
-
+         public bool? HasMedia { get; set; }
+        public bool? HasComment { get; set; }
+        public bool? HasCheckins { get; set; }
         /// <summary>
         /// list of (lat,lng) points to search along (route etc)
         /// </summary>
@@ -219,7 +221,9 @@ namespace OCM.API.Common
                 settings.MaxPowerKW = ParseDouble(requestParams["maxpowerkw"]);
                 if (settings.MaxPowerKW < 1) settings.MaxPowerKW = null;
             }
-
+            if (!String.IsNullOrEmpty(requestParams["hasmedia"])) settings.HasMedia = ParseBoolNullable(requestParams["hasmedia"]);
+            if (!String.IsNullOrEmpty(requestParams["hascomment"])) settings.HasComment = ParseBoolNullable(requestParams["hascomment"]);
+            if (!String.IsNullOrEmpty(requestParams["hascheckins"])) settings.HasCheckins = ParseBoolNullable(requestParams["hascheckins"]);
             if (!String.IsNullOrEmpty(requestParams["dataprovidername"])) settings.DataProviderName = ParseString(requestParams["dataprovidername"]);
             if (!String.IsNullOrEmpty(requestParams["locationtitle"])) settings.LocationTitle = ParseString(requestParams["locationtitle"]);
             if (!String.IsNullOrEmpty(requestParams["address"])) settings.Address = ParseString(requestParams["address"]);
@@ -332,6 +336,9 @@ namespace OCM.API.Common
                 if (DataProviderIDs != null) key += ":prov_id:" + IntArrayToString(DataProviderIDs);
                 if (IsOpenData != null) key += ":opendata:" + IsOpenData.ToString();
                 if (MinPowerKW != null) key += ":minpowerkw:" + MinPowerKW.ToString();
+                if (HasMedia != null) key += ":hasmedia:" + HasMedia.ToString();
+                if (HasComment != null) key += ":hascomment:" + HasComment.ToString();
+                if (HasCheckins != null) key += ":hascheckins:" + HasCheckins.ToString();
                 if (Polyline != null) key += ":polyline:" + Polyline.GetHashCode().ToString();
                 if (Polygon != null) key += ":polygon:" + Polygon.GetHashCode().ToString();
                 if (BoundingBox != null) key += ":boundingbox:" + BoundingBox.GetHashCode().ToString();

--- a/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
+++ b/API/OCM.Net/OCM.API.Core/Util/CacheProviderMongoDB.cs
@@ -1310,6 +1310,41 @@ namespace OCM.Core.Data
             {
                 poiList = poiList.Where(c => c.Connections.Any(conn => conn.LevelID != null && filter.LevelIDs.Contains((int)conn.LevelID)));
             }
+            if (filter.HasMedia != null)
+            {
+                if (filter.HasMedia == true)
+                {
+                    poiList = poiList.Where(c => c.MediaItems != null && c.MediaItems.Any(m => m.IsEnabled));
+                }
+                else
+                {
+                    poiList = poiList.Where(c => c.MediaItems == null || !c.MediaItems.Any(m => m.IsEnabled));
+                }
+            }
+
+            if (filter.HasComment != null)
+            {
+                if (filter.HasComment == true)
+                {
+                    poiList = poiList.Where(c => c.UserComments != null && c.UserComments.Any());
+                }
+                else
+                {
+                    poiList = poiList.Where(c => c.UserComments == null || !c.UserComments.Any());
+                }
+            }
+
+            if (filter.HasCheckins != null)
+            {
+                if (filter.HasCheckins == true)
+                {
+                    poiList = poiList.Where(c => c.UserComments != null && c.UserComments.Any(comment => comment.CheckinStatusTypeID != null));
+                }
+                else
+                {
+                    poiList = poiList.Where(c => c.UserComments == null || !c.UserComments.Any(comment => comment.CheckinStatusTypeID != null));
+                }
+            }
 
             poiList = poiList.Where(c => c.AddressInfo != null);
             return poiList;

--- a/Website/OCM.Web/Views/POI/_POISearch.cshtml
+++ b/Website/OCM.Web/Views/POI/_POISearch.cshtml
@@ -128,6 +128,36 @@
                     @Html.DropDownList("submissionstatustypeid", Model.SubmissionTypeList, new { @class = "form-control" })
                 </div>
             </div>
+             <div class="form-group">
+                <label class="control-label col-md-4" for="hasmedia">Media</label>
+                <div class="col-md-8">
+                    <select id="hasmedia" name="HasMedia" class="form-control">
+                        <option value="" selected="@(Model.HasMedia == null ? "selected" : null)">Any</option>
+                        <option value="true" selected="@(Model.HasMedia == true ? "selected" : null)">Has media</option>
+                        <option value="false" selected="@(Model.HasMedia == false ? "selected" : null)">No media</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="control-label col-md-4" for="hascomment">Comments</label>
+                <div class="col-md-8">
+                    <select id="hascomment" name="HasComment" class="form-control">
+                        <option value="" selected="@(Model.HasComment == null ? "selected" : null)">Any</option>
+                        <option value="true" selected="@(Model.HasComment == true ? "selected" : null)">Has comments</option>
+                        <option value="false" selected="@(Model.HasComment == false ? "selected" : null)">No comments</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="control-label col-md-4" for="hascheckins">Check-ins</label>
+                <div class="col-md-8">
+                    <select id="hascheckins" name="HasCheckins" class="form-control">
+                        <option value="" selected="@(Model.HasCheckins == null ? "selected" : null)">Any</option>
+                        <option value="true" selected="@(Model.HasCheckins == true ? "selected" : null)">Has check-ins</option>
+                        <option value="false" selected="@(Model.HasCheckins == false ? "selected" : null)">No check-ins</option>
+                    </select>
+                </div>
+            </div>
         </div>
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-7">


### PR DESCRIPTION
Related to [#16](https://github.com/openchargemap/ocm-app/issues/16)

This PR adds filtering on the website for POI search results by:
- Photos (hasmedia)
- Comments (hascomment)
- Check-ins (hascheckins)

The filters are exposed via simple Any/Yes/No controls and passed through as query
parameters only when selected, preserving existing default behavior.

No API logic is changed here — this PR only covers the MVC/website side.