### PR TITLE
Add country operator editor workflow

### DIFF
--- a/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
@@ -41,6 +41,13 @@ namespace OCM.API.Common
                  SimilarTitle(o.Title, title))).ToList();
         }
 
+        public bool HasWebsiteMatch(string websiteUrl, int? excludedId = null)
+        {
+            var websiteHost = GetWebsiteHost(websiteUrl);
+            return !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.Any(o =>
+                (!excludedId.HasValue || o.Id != excludedId.Value) && GetWebsiteHost(o.WebsiteUrl) == websiteHost);
+        }
+
         private static string GetEmailDomain(string email)
         {
             if (string.IsNullOrWhiteSpace(email)) return null;

--- a/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
@@ -44,7 +44,7 @@ namespace OCM.API.Common
         public bool HasWebsiteMatch(string websiteUrl, int? excludedId = null)
         {
             var websiteHost = GetWebsiteHost(websiteUrl);
-            return !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.Any(o =>
+            return !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.AsEnumerable().Any(o =>
                 (!excludedId.HasValue || o.Id != excludedId.Value) && GetWebsiteHost(o.WebsiteUrl) == websiteHost);
         }
 
@@ -75,11 +75,11 @@ namespace OCM.API.Common
             }
             var title = $"{name} ({country.Isocode.ToUpperInvariant()})";
             var existing = update.ID > 1 ? dataModel.Operators.FirstOrDefault(o => o.Id == update.ID) : null;
-            var duplicateTitle = dataModel.Operators.Any(o => (existing == null || o.Id != existing.Id) && NormalizeTitle(o.Title) == NormalizeTitle(title));
+            var duplicateTitle = dataModel.Operators.AsEnumerable().Any(o => (existing == null || o.Id != existing.Id) && NormalizeTitle(o.Title) == NormalizeTitle(title));
             if (duplicateTitle) throw new InvalidOperationException("An operator with this title already exists.");
 
             var websiteHost = GetWebsiteHost(update.WebsiteURL);
-            var websiteMatch = !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.Any(o => (existing == null || o.Id != existing.Id) && GetWebsiteHost(o.WebsiteUrl) == websiteHost);
+            var websiteMatch = !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.AsEnumerable().Any(o => (existing == null || o.Id != existing.Id) && GetWebsiteHost(o.WebsiteUrl) == websiteHost);
             if (websiteMatch && !confirmWebsiteMatch) throw new InvalidOperationException("An operator with the same website already exists. Confirm this is not a duplicate.");
 
             var isUpdate = existing != null;

--- a/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
+++ b/API/OCM.Net/OCM.API.Core/Common/OperatorInfoManager.cs
@@ -1,5 +1,6 @@
 ﻿using OCM.API.Common.Model;
 using OCM.Core.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +8,97 @@ namespace OCM.API.Common
 {
     public class OperatorInfoManager : ManagerBase
     {
+        public static string NormalizeTitle(string title)
+        {
+            return string.IsNullOrWhiteSpace(title)
+                ? string.Empty
+                : new string(title.Trim().Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+        }
+
+        public static string GetWebsiteHost(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return null;
+
+            if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+            {
+                Uri.TryCreate("https://" + url.Trim(), UriKind.Absolute, out uri);
+            }
+
+            var host = uri?.Host?.Trim().ToLowerInvariant();
+            return host != null && host.StartsWith("www.", StringComparison.Ordinal) ? host.Substring(4) : host;
+        }
+
+        public List<OperatorInfo> FindPotentialDuplicates(string title, string websiteUrl, string contactEmail, int? excludedId = null)
+        {
+            var normalizedTitle = NormalizeTitle(title);
+            var websiteHost = GetWebsiteHost(websiteUrl);
+            var contactDomain = GetEmailDomain(contactEmail);
+
+            return GetOperators().Where(o => (!excludedId.HasValue || o.ID != excludedId.Value) &&
+                (NormalizeTitle(o.Title) == normalizedTitle ||
+                 (!string.IsNullOrEmpty(websiteHost) && GetWebsiteHost(o.WebsiteURL) == websiteHost) ||
+                 (!string.IsNullOrEmpty(contactDomain) && GetEmailDomain(o.ContactEmail) == contactDomain) ||
+                 SimilarTitle(o.Title, title))).ToList();
+        }
+
+        private static string GetEmailDomain(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email)) return null;
+            var at = email.LastIndexOf('@');
+            return at > 0 ? email.Substring(at + 1).Trim().ToLowerInvariant() : null;
+        }
+
+        private static bool SimilarTitle(string left, string right)
+        {
+            var a = NormalizeTitle(left);
+            var b = NormalizeTitle(right);
+            return a.Length >= 4 && b.Length >= 4 && (a.Contains(b) || b.Contains(a));
+        }
+
+        public OperatorInfo SaveCountryOperator(int userId, int countryId, OperatorInfo update, bool confirmWebsiteMatch)
+        {
+            var country = dataModel.Countries.FirstOrDefault(c => c.Id == countryId);
+            if (country == null) throw new ArgumentException("Unknown country", nameof(countryId));
+
+            var name = (update.Title ?? string.Empty).Trim();
+            var countrySuffix = " (" + country.Isocode.Trim().ToUpperInvariant() + ")";
+            if (name.EndsWith(countrySuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                name = name.Substring(0, name.Length - countrySuffix.Length).Trim();
+            }
+            var title = $"{name} ({country.Isocode.ToUpperInvariant()})";
+            var existing = update.ID > 1 ? dataModel.Operators.FirstOrDefault(o => o.Id == update.ID) : null;
+            var duplicateTitle = dataModel.Operators.Any(o => (existing == null || o.Id != existing.Id) && NormalizeTitle(o.Title) == NormalizeTitle(title));
+            if (duplicateTitle) throw new InvalidOperationException("An operator with this title already exists.");
+
+            var websiteHost = GetWebsiteHost(update.WebsiteURL);
+            var websiteMatch = !string.IsNullOrEmpty(websiteHost) && dataModel.Operators.Any(o => (existing == null || o.Id != existing.Id) && GetWebsiteHost(o.WebsiteUrl) == websiteHost);
+            if (websiteMatch && !confirmWebsiteMatch) throw new InvalidOperationException("An operator with the same website already exists. Confirm this is not a duplicate.");
+
+            var isUpdate = existing != null;
+            if (existing == null)
+            {
+                existing = new OCM.Core.Data.Operator();
+                dataModel.Operators.Add(existing);
+            }
+
+            existing.Title = title;
+            existing.WebsiteUrl = update.WebsiteURL;
+            existing.Comments = update.Comments;
+            existing.PhonePrimaryContact = update.PhonePrimaryContact;
+            existing.PhoneSecondaryContact = update.PhoneSecondaryContact;
+            existing.BookingUrl = update.BookingURL;
+            existing.ContactEmail = update.ContactEmail;
+            existing.FaultReportEmail = update.FaultReportEmail;
+
+            dataModel.SaveChanges();
+            var result = Model.Extensions.OperatorInfo.FromDataModel(existing);
+            var user = new UserManager().GetUser(userId);
+            AuditLogManager.Log(user, isUpdate ? AuditEventType.UpdatedItem : AuditEventType.CreatedItem, "{EntityType:\"Operator\",EntityID:" + result.ID + "}", $"User {(isUpdate ? "updated" : "added")} country operator {result.ID} {result.Title}");
+            CacheManager.RefreshCachedData();
+            return result;
+        }
+
         public OperatorInfo GetOperatorInfo(int id)
         {
             var operatorInfo = DataModel.Operators.FirstOrDefault(o => o.Id == id);

--- a/Tests/OCM.API.Tests/CountryOperatorTests.cs
+++ b/Tests/OCM.API.Tests/CountryOperatorTests.cs
@@ -3,12 +3,12 @@ using Xunit;
 
 namespace OCM.API.Tests
 {
-    public class OperatorInfoManagerTests
+    public class CountryOperatorTests
     {
         [Theory]
         [InlineData(" Example Charge (ES) ", "examplechargees")]
         [InlineData("Example-Charge", "examplecharge")]
-        public void NormalizeTitle_is_case_and_punctuation_insensitive(string title, string expected)
+        public void Duplicate_title_normalization_is_case_and_punctuation_insensitive(string title, string expected)
         {
             Assert.Equal(expected, OperatorInfoManager.NormalizeTitle(title));
         }
@@ -16,9 +16,10 @@ namespace OCM.API.Tests
         [Theory]
         [InlineData("https://www.example.com/path", "example.com")]
         [InlineData("example.com", "example.com")]
-        public void GetWebsiteHost_returns_normalized_host(string url, string expected)
+        public void Duplicate_website_matching_uses_the_normalized_host(string url, string expected)
         {
             Assert.Equal(expected, OperatorInfoManager.GetWebsiteHost(url));
         }
+
     }
 }

--- a/Tests/OCM.API.Tests/OperatorInfoManagerTests.cs
+++ b/Tests/OCM.API.Tests/OperatorInfoManagerTests.cs
@@ -1,0 +1,24 @@
+using OCM.API.Common;
+using Xunit;
+
+namespace OCM.API.Tests
+{
+    public class OperatorInfoManagerTests
+    {
+        [Theory]
+        [InlineData(" Example Charge (ES) ", "examplechargees")]
+        [InlineData("Example-Charge", "examplecharge")]
+        public void NormalizeTitle_is_case_and_punctuation_insensitive(string title, string expected)
+        {
+            Assert.Equal(expected, OperatorInfoManager.NormalizeTitle(title));
+        }
+
+        [Theory]
+        [InlineData("https://www.example.com/path", "example.com")]
+        [InlineData("example.com", "example.com")]
+        public void GetWebsiteHost_returns_normalized_host(string url, string expected)
+        {
+            Assert.Equal(expected, OperatorInfoManager.GetWebsiteHost(url));
+        }
+    }
+}

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -115,7 +115,9 @@ namespace OCM.MVC.Controllers
                     FaultReportEmail = model.FaultReportEmail
                 }, model.ConfirmWebsiteMatch);
 
-                TempData["StatusMessage"] = $"Saved operator {saved.Title}.";
+                TempData["StatusMessage"] = model.ID > 1
+                    ? $"Updated operator {saved.Title}."
+                    : $"Created operator {saved.Title}.";
                 return RedirectToAction(nameof(Edit), new { id = saved.ID, countryId = model.CountryID });
             }
             catch (InvalidOperationException ex)

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -44,6 +44,9 @@ namespace OCM.MVC.Controllers
                 model.WebsiteURL,
                 model.ContactEmail,
                 model.ID > 1 ? model.ID : (int?)null);
+            ViewBag.HasWebsiteMatch = manager.HasWebsiteMatch(
+                model.WebsiteURL,
+                model.ID > 1 ? model.ID : (int?)null);
         }
 
         [HttpGet]

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OCM.API.Common;
+using OCM.API.Common.Model;
+using OCM.Web.Models;
+
+namespace OCM.MVC.Controllers
+{
+    [Authorize]
+    public class CountryOperatorsController : BaseController
+    {
+        private User GetCurrentUser()
+        {
+            return UserID.HasValue ? new UserManager().GetUser(UserID.Value) : null;
+        }
+
+        private List<Country> GetEditableCountries(User user)
+        {
+            if (user == null) return new List<Country>();
+
+            return new ReferenceDataManager().GetCountries(false)
+                .Where(c => UserManager.HasUserPermission(user, c.ID, PermissionLevel.Editor))
+                .OrderBy(c => c.Title)
+                .ToList();
+        }
+
+        private bool CanEditCountry(User user, int countryId)
+        {
+            return GetEditableCountries(user).Any(c => c.ID == countryId);
+        }
+
+        private void PopulateCountries(IEnumerable<Country> countries, int selectedCountryId)
+        {
+            ViewBag.CountryList = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(countries, "ID", "Title", selectedCountryId);
+        }
+
+        private void PopulateDuplicateWarnings(OperatorInfoManager manager, CountryOperatorEditModel model)
+        {
+            ViewBag.PotentialDuplicates = manager.FindPotentialDuplicates(
+                model.OperatorName,
+                model.WebsiteURL,
+                model.ContactEmail,
+                model.ID > 1 ? model.ID : (int?)null);
+        }
+
+        [HttpGet]
+        public ActionResult Edit(int? id, int? countryId)
+        {
+            var user = GetCurrentUser();
+            var countries = GetEditableCountries(user);
+            if (countries.Count == 0) return Forbid();
+
+            var model = new CountryOperatorEditModel { CountryID = countryId ?? countries[0].ID };
+            if (id.HasValue)
+            {
+                var operatorInfo = new OperatorInfoManager().GetOperatorInfo(id.Value);
+                var country = countries.FirstOrDefault(c => operatorInfo != null && operatorInfo.Title.EndsWith(" (" + c.ISOCode + ")", StringComparison.OrdinalIgnoreCase));
+                if (country == null) return Forbid();
+
+                model.ID = operatorInfo.ID;
+                model.CountryID = country.ID;
+                model.OperatorName = operatorInfo.Title.Substring(0, operatorInfo.Title.Length - country.ISOCode.Length - 3);
+                model.WebsiteURL = operatorInfo.WebsiteURL;
+                model.Comments = operatorInfo.Comments;
+                model.PhonePrimaryContact = operatorInfo.PhonePrimaryContact;
+                model.PhoneSecondaryContact = operatorInfo.PhoneSecondaryContact;
+                model.BookingURL = operatorInfo.BookingURL;
+                model.ContactEmail = operatorInfo.ContactEmail;
+                model.FaultReportEmail = operatorInfo.FaultReportEmail;
+            }
+
+            PopulateCountries(countries, model.CountryID);
+            return View(model);
+        }
+
+        [HttpPost, ValidateAntiForgeryToken]
+        public ActionResult Edit(CountryOperatorEditModel model)
+        {
+            var user = GetCurrentUser();
+            var countries = GetEditableCountries(user);
+            if (countries.Count == 0 || !CanEditCountry(user, model.CountryID)) return Forbid();
+
+            PopulateCountries(countries, model.CountryID);
+            PopulateDuplicateWarnings(new OperatorInfoManager(), model);
+            if (!ModelState.IsValid) return View(model);
+
+            if (model.ID > 1)
+            {
+                var existing = new OperatorInfoManager().GetOperatorInfo(model.ID);
+                if (existing == null) return NotFound();
+                var suffix = " (" + countries.First(c => c.ID == model.CountryID).ISOCode + ")";
+                if (!existing.Title.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) return Forbid();
+            }
+
+            try
+            {
+                var manager = new OperatorInfoManager();
+                PopulateDuplicateWarnings(manager, model);
+                var saved = manager.SaveCountryOperator((int)UserID, model.CountryID, new OperatorInfo
+                {
+                    ID = model.ID,
+                    Title = model.OperatorName,
+                    WebsiteURL = model.WebsiteURL,
+                    Comments = model.Comments,
+                    PhonePrimaryContact = model.PhonePrimaryContact,
+                    PhoneSecondaryContact = model.PhoneSecondaryContact,
+                    BookingURL = model.BookingURL,
+                    ContactEmail = model.ContactEmail,
+                    FaultReportEmail = model.FaultReportEmail
+                }, model.ConfirmWebsiteMatch);
+
+                return RedirectToAction(nameof(Edit), new { id = saved.ID, countryId = model.CountryID });
+            }
+            catch (InvalidOperationException ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+                return View(model);
+            }
+        }
+    }
+}

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -21,7 +21,10 @@ namespace OCM.MVC.Controllers
         {
             if (user == null) return new List<Country>();
 
-            return new ReferenceDataManager().GetCountries(false)
+            var countries = new ReferenceDataManager().GetCountries(false);
+            if (UserManager.IsUserAdministrator(user)) return countries;
+
+            return countries
                 .Where(c => UserManager.HasUserPermission(user, c.ID, PermissionLevel.Editor))
                 .OrderBy(c => c.Title)
                 .ToList();

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -9,7 +9,7 @@ using OCM.Web.Models;
 
 namespace OCM.MVC.Controllers
 {
-    [Authorize]
+    [Authorize(Roles = "StandardUser")]
     public class CountryOperatorsController : BaseController
     {
         private User GetCurrentUser()

--- a/Website/OCM.Web/Controllers/CountryOperatorsController.cs
+++ b/Website/OCM.Web/Controllers/CountryOperatorsController.cs
@@ -115,6 +115,7 @@ namespace OCM.MVC.Controllers
                     FaultReportEmail = model.FaultReportEmail
                 }, model.ConfirmWebsiteMatch);
 
+                TempData["StatusMessage"] = $"Saved operator {saved.Title}.";
                 return RedirectToAction(nameof(Edit), new { id = saved.ID, countryId = model.CountryID });
             }
             catch (InvalidOperationException ex)

--- a/Website/OCM.Web/Models/CountryOperatorEditModel.cs
+++ b/Website/OCM.Web/Models/CountryOperatorEditModel.cs
@@ -7,6 +7,7 @@ namespace OCM.Web.Models
         public int ID { get; set; }
 
         [Required]
+        [Display(Name = "Country")]
         public int CountryID { get; set; }
 
         [Required, StringLength(200)]
@@ -14,25 +15,33 @@ namespace OCM.Web.Models
         public string OperatorName { get; set; }
 
         [DataType(DataType.Url)]
+        [Display(Name = "Website")]
         public string WebsiteURL { get; set; }
 
+        [Display(Name = "Notes")]
         public string Comments { get; set; }
 
         [DataType(DataType.PhoneNumber)]
+        [Display(Name = "Primary phone")]
         public string PhonePrimaryContact { get; set; }
 
         [DataType(DataType.PhoneNumber)]
+        [Display(Name = "Secondary phone")]
         public string PhoneSecondaryContact { get; set; }
 
         [DataType(DataType.Url)]
+        [Display(Name = "Booking URL")]
         public string BookingURL { get; set; }
 
         [DataType(DataType.EmailAddress)]
+        [Display(Name = "Contact email")]
         public string ContactEmail { get; set; }
 
         [DataType(DataType.EmailAddress)]
+        [Display(Name = "Fault-report email")]
         public string FaultReportEmail { get; set; }
 
+        [Display(Name = "Confirm website match")]
         public bool ConfirmWebsiteMatch { get; set; }
     }
 }

--- a/Website/OCM.Web/Models/CountryOperatorEditModel.cs
+++ b/Website/OCM.Web/Models/CountryOperatorEditModel.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OCM.Web.Models
+{
+    public class CountryOperatorEditModel
+    {
+        public int ID { get; set; }
+
+        [Required]
+        public int CountryID { get; set; }
+
+        [Required, StringLength(200)]
+        [Display(Name = "Operator name")]
+        public string OperatorName { get; set; }
+
+        [DataType(DataType.Url)]
+        public string WebsiteURL { get; set; }
+
+        public string Comments { get; set; }
+
+        [DataType(DataType.PhoneNumber)]
+        public string PhonePrimaryContact { get; set; }
+
+        [DataType(DataType.PhoneNumber)]
+        public string PhoneSecondaryContact { get; set; }
+
+        [DataType(DataType.Url)]
+        public string BookingURL { get; set; }
+
+        [DataType(DataType.EmailAddress)]
+        public string ContactEmail { get; set; }
+
+        [DataType(DataType.EmailAddress)]
+        public string FaultReportEmail { get; set; }
+
+        public bool ConfirmWebsiteMatch { get; set; }
+    }
+}

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -4,71 +4,117 @@
 
 @{
     ViewBag.Title = Model.ID > 1 ? "Edit Country Operator" : "Add Country Operator";
+    var possibleDuplicates = ViewBag.PotentialDuplicates as IEnumerable<OCM.API.Common.Model.OperatorInfo>;
 }
 
-<h2>@ViewBag.Title</h2>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12 col-lg-10 col-xl-8">
+            <h2 class="mb-2">@ViewBag.Title</h2>
+            <p class="text-muted mb-4">Maintain the operator label used for charging locations in the selected country.</p>
 
-@using (Html.BeginForm())
-{
-    @Html.AntiForgeryToken()
-    @Html.ValidationSummary(true)
-    @Html.HiddenFor(model => model.ID)
+            @using (Html.BeginForm())
+            {
+                @Html.AntiForgeryToken()
+                @Html.ValidationSummary(true, "Please correct the following:", new { @class = "alert alert-danger" })
+                @Html.HiddenFor(model => model.ID)
 
-    @if (ViewBag.PotentialDuplicates != null && ((IEnumerable<OCM.API.Common.Model.OperatorInfo>)ViewBag.PotentialDuplicates).Any())
-    {
-        <div class="alert alert-warning">
-            <strong>Possible existing operators</strong>
-            <ul>
-                @foreach (var duplicate in (IEnumerable<OCM.API.Common.Model.OperatorInfo>)ViewBag.PotentialDuplicates)
-                {
-                    <li>@duplicate.Title</li>
-                }
-            </ul>
+                <fieldset class="card mb-4">
+                    <legend class="card-header h5 mb-0">Identity</legend>
+                    <div class="card-body">
+                        <div class="form-group">
+                            @Html.LabelFor(model => model.CountryID)
+                            @Html.DropDownListFor(model => model.CountryID, (SelectList)ViewBag.CountryList, "Select a country", new { @class = "form-control" })
+                            @Html.ValidationMessageFor(model => model.CountryID)
+                            <small class="form-text text-muted">The country code is added to the saved operator title automatically.</small>
+                        </div>
+                        <div class="form-group mb-0">
+                            @Html.LabelFor(model => model.OperatorName)
+                            @Html.EditorFor(model => model.OperatorName, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.ValidationMessageFor(model => model.OperatorName)
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset class="card mb-4">
+                    <legend class="card-header h5 mb-0">Public links</legend>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                @Html.LabelFor(model => model.WebsiteURL)
+                                @Html.EditorFor(model => model.WebsiteURL, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.ValidationMessageFor(model => model.WebsiteURL)
+                            </div>
+                            <div class="col-md-6 form-group mb-md-0">
+                                @Html.LabelFor(model => model.BookingURL)
+                                @Html.EditorFor(model => model.BookingURL, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.ValidationMessageFor(model => model.BookingURL)
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset class="card mb-4">
+                    <legend class="card-header h5 mb-0">Contact details</legend>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                @Html.LabelFor(model => model.PhonePrimaryContact)
+                                @Html.EditorFor(model => model.PhonePrimaryContact, new { htmlAttributes = new { @class = "form-control" } })
+                            </div>
+                            <div class="col-md-6 form-group mb-md-0">
+                                @Html.LabelFor(model => model.PhoneSecondaryContact)
+                                @Html.EditorFor(model => model.PhoneSecondaryContact, new { htmlAttributes = new { @class = "form-control" } })
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                @Html.LabelFor(model => model.ContactEmail)
+                                @Html.EditorFor(model => model.ContactEmail, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.ValidationMessageFor(model => model.ContactEmail)
+                            </div>
+                            <div class="col-md-6 form-group mb-0">
+                                @Html.LabelFor(model => model.FaultReportEmail)
+                                @Html.EditorFor(model => model.FaultReportEmail, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.ValidationMessageFor(model => model.FaultReportEmail)
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset class="card mb-4">
+                    <legend class="card-header h5 mb-0">Notes and validation</legend>
+                    <div class="card-body">
+                        <div class="form-group">
+                            @Html.LabelFor(model => model.Comments)
+                            @Html.TextAreaFor(model => model.Comments, new { @class = "form-control", rows = 4 })
+                        </div>
+
+                        @if (possibleDuplicates != null && possibleDuplicates.Any())
+                        {
+                            <div class="alert alert-warning mb-3">
+                                <strong>Possible existing operators</strong>
+                                <ul class="mb-0">
+                                    @foreach (var duplicate in possibleDuplicates)
+                                    {
+                                        <li>@duplicate.Title</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+
+                        <div class="custom-control custom-checkbox">
+                            @Html.CheckBoxFor(model => model.ConfirmWebsiteMatch, new { @class = "custom-control-input" })
+                            @Html.LabelFor(model => model.ConfirmWebsiteMatch, "Confirm this is not a duplicate when the website matches an existing operator", new { @class = "custom-control-label" })
+                        </div>
+                    </div>
+                </fieldset>
+
+                <div class="d-flex flex-wrap mb-4">
+                    <input type="submit" value="Save operator" class="btn btn-primary mr-2 mb-2" />
+                    <a href="@Url.Action("Index", "Home")" class="btn btn-outline-secondary mb-2">Cancel</a>
+                </div>
+            }
         </div>
-    }
-
-    <div class="form-group">
-        @Html.LabelFor(model => model.CountryID)
-        @Html.DropDownListFor(model => model.CountryID, (SelectList)ViewBag.CountryList, "Select a country", new { @class = "form-control" })
-        @Html.ValidationMessageFor(model => model.CountryID)
     </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.OperatorName)
-        @Html.EditorFor(model => model.OperatorName, new { htmlAttributes = new { @class = "form-control" } })
-        @Html.ValidationMessageFor(model => model.OperatorName)
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.WebsiteURL)
-        @Html.EditorFor(model => model.WebsiteURL, new { htmlAttributes = new { @class = "form-control" } })
-        @Html.ValidationMessageFor(model => model.WebsiteURL)
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.Comments)
-        @Html.TextAreaFor(model => model.Comments, new { @class = "form-control" })
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.PhonePrimaryContact)
-        @Html.EditorFor(model => model.PhonePrimaryContact, new { htmlAttributes = new { @class = "form-control" } })
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.PhoneSecondaryContact)
-        @Html.EditorFor(model => model.PhoneSecondaryContact, new { htmlAttributes = new { @class = "form-control" } })
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.BookingURL)
-        @Html.EditorFor(model => model.BookingURL, new { htmlAttributes = new { @class = "form-control" } })
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.ContactEmail)
-        @Html.EditorFor(model => model.ContactEmail, new { htmlAttributes = new { @class = "form-control" } })
-    </div>
-    <div class="form-group">
-        @Html.LabelFor(model => model.FaultReportEmail)
-        @Html.EditorFor(model => model.FaultReportEmail, new { htmlAttributes = new { @class = "form-control" } })
-    </div>
-    <div class="checkbox">
-        @Html.CheckBoxFor(model => model.ConfirmWebsiteMatch)
-        @Html.LabelFor(model => model.ConfirmWebsiteMatch, "Confirm this is not a duplicate when the website matches an existing operator")
-    </div>
-    <p><input type="submit" value="Save" class="btn btn-primary" /></p>
-}
+</div>

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -5,13 +5,14 @@
 @{
     ViewBag.Title = Model.ID > 1 ? "Edit Country Operator" : "Add Country Operator";
     var possibleDuplicates = ViewBag.PotentialDuplicates as IEnumerable<OCM.API.Common.Model.OperatorInfo>;
+    var isEditing = Model.ID > 1;
 }
 
 <div class="container-fluid">
     <div class="row">
         <div class="col-12 col-lg-10 col-xl-8">
             <h2 class="mb-2">@ViewBag.Title</h2>
-            <p class="text-muted mb-4">Add or update the operator name shown for charging locations in this country.</p>
+            <p class="text-muted mb-4">@(isEditing ? "Update this operator’s details for the selected country." : "Create an operator label for charging locations in the selected country.")</p>
 
             @if (TempData["StatusMessage"] != null)
             {
@@ -119,7 +120,7 @@
                 </div>
 
                 <div class="d-flex flex-wrap mb-4">
-                    <input type="submit" value="Save operator" class="btn btn-primary mr-2 mb-2" />
+                    <input type="submit" value="@(isEditing ? "Save changes" : "Create operator")" class="btn btn-primary mr-2 mb-2" />
                     <a href="@Url.Action("Index", "Home")" class="btn btn-outline-secondary mb-2">Cancel</a>
                 </div>
             }

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="col-12 col-lg-10 col-xl-8">
             <h2 class="mb-2">@ViewBag.Title</h2>
-            <p class="text-muted mb-4">Maintain the operator label used for charging locations in the selected country.</p>
+            <p class="text-muted mb-4">Add or update the operator name shown for charging locations in this country.</p>
 
             @using (Html.BeginForm())
             {

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -13,6 +13,11 @@
             <h2 class="mb-2">@ViewBag.Title</h2>
             <p class="text-muted mb-4">Add or update the operator name shown for charging locations in this country.</p>
 
+            @if (TempData["StatusMessage"] != null)
+            {
+                <div class="alert alert-success">@TempData["StatusMessage"]</div>
+            }
+
             @using (Html.BeginForm())
             {
                 @Html.AntiForgeryToken()

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -19,8 +19,8 @@
                 @Html.ValidationSummary(true, "Please correct the following:", new { @class = "alert alert-danger" })
                 @Html.HiddenFor(model => model.ID)
 
-                <fieldset class="card mb-4">
-                    <legend class="card-header h5 mb-0">Identity</legend>
+                <div class="card mb-4">
+                    <div class="card-header h5 mb-0">Identity</div>
                     <div class="card-body">
                         <div class="form-group">
                             @Html.LabelFor(model => model.CountryID)
@@ -34,10 +34,10 @@
                             @Html.ValidationMessageFor(model => model.OperatorName)
                         </div>
                     </div>
-                </fieldset>
+                </div>
 
-                <fieldset class="card mb-4">
-                    <legend class="card-header h5 mb-0">Public links</legend>
+                <div class="card mb-4">
+                    <div class="card-header h5 mb-0">Public links</div>
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-6 form-group">
@@ -52,10 +52,10 @@
                             </div>
                         </div>
                     </div>
-                </fieldset>
+                </div>
 
-                <fieldset class="card mb-4">
-                    <legend class="card-header h5 mb-0">Contact details</legend>
+                <div class="card mb-4">
+                    <div class="card-header h5 mb-0">Contact details</div>
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-6 form-group">
@@ -80,10 +80,10 @@
                             </div>
                         </div>
                     </div>
-                </fieldset>
+                </div>
 
-                <fieldset class="card mb-4">
-                    <legend class="card-header h5 mb-0">Notes and validation</legend>
+                <div class="card mb-4">
+                    <div class="card-header h5 mb-0">Notes and validation</div>
                     <div class="card-body">
                         <div class="form-group">
                             @Html.LabelFor(model => model.Comments)
@@ -108,7 +108,7 @@
                             @Html.LabelFor(model => model.ConfirmWebsiteMatch, "Confirm this is not a duplicate when the website matches an existing operator", new { @class = "custom-control-label" })
                         </div>
                     </div>
-                </fieldset>
+                </div>
 
                 <div class="d-flex flex-wrap mb-4">
                     <input type="submit" value="Save operator" class="btn btn-primary mr-2 mb-2" />

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -24,7 +24,7 @@
                     <div class="card-body">
                         <div class="form-group">
                             @Html.LabelFor(model => model.CountryID)
-                            @Html.DropDownListFor(model => model.CountryID, (SelectList)ViewBag.CountryList, "Select a country", new { @class = "form-control" })
+                            @Html.DropDownListFor(model => model.CountryID, (SelectList)ViewBag.CountryList, "Select a country", new { @class = "custom-select" })
                             @Html.ValidationMessageFor(model => model.CountryID)
                             <small class="form-text text-muted">The country code is added to the saved operator title automatically.</small>
                         </div>

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -1,0 +1,74 @@
+@model OCM.Web.Models.CountryOperatorEditModel
+@using System.Collections.Generic
+@using System.Linq
+
+@{
+    ViewBag.Title = Model.ID > 1 ? "Edit Country Operator" : "Add Country Operator";
+}
+
+<h2>@ViewBag.Title</h2>
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    @Html.ValidationSummary(true)
+    @Html.HiddenFor(model => model.ID)
+
+    @if (ViewBag.PotentialDuplicates != null && ((IEnumerable<OCM.API.Common.Model.OperatorInfo>)ViewBag.PotentialDuplicates).Any())
+    {
+        <div class="alert alert-warning">
+            <strong>Possible existing operators</strong>
+            <ul>
+                @foreach (var duplicate in (IEnumerable<OCM.API.Common.Model.OperatorInfo>)ViewBag.PotentialDuplicates)
+                {
+                    <li>@duplicate.Title</li>
+                }
+            </ul>
+        </div>
+    }
+
+    <div class="form-group">
+        @Html.LabelFor(model => model.CountryID)
+        @Html.DropDownListFor(model => model.CountryID, (SelectList)ViewBag.CountryList, "Select a country", new { @class = "form-control" })
+        @Html.ValidationMessageFor(model => model.CountryID)
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.OperatorName)
+        @Html.EditorFor(model => model.OperatorName, new { htmlAttributes = new { @class = "form-control" } })
+        @Html.ValidationMessageFor(model => model.OperatorName)
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.WebsiteURL)
+        @Html.EditorFor(model => model.WebsiteURL, new { htmlAttributes = new { @class = "form-control" } })
+        @Html.ValidationMessageFor(model => model.WebsiteURL)
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.Comments)
+        @Html.TextAreaFor(model => model.Comments, new { @class = "form-control" })
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.PhonePrimaryContact)
+        @Html.EditorFor(model => model.PhonePrimaryContact, new { htmlAttributes = new { @class = "form-control" } })
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.PhoneSecondaryContact)
+        @Html.EditorFor(model => model.PhoneSecondaryContact, new { htmlAttributes = new { @class = "form-control" } })
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.BookingURL)
+        @Html.EditorFor(model => model.BookingURL, new { htmlAttributes = new { @class = "form-control" } })
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.ContactEmail)
+        @Html.EditorFor(model => model.ContactEmail, new { htmlAttributes = new { @class = "form-control" } })
+    </div>
+    <div class="form-group">
+        @Html.LabelFor(model => model.FaultReportEmail)
+        @Html.EditorFor(model => model.FaultReportEmail, new { htmlAttributes = new { @class = "form-control" } })
+    </div>
+    <div class="checkbox">
+        @Html.CheckBoxFor(model => model.ConfirmWebsiteMatch)
+        @Html.LabelFor(model => model.ConfirmWebsiteMatch, "Confirm this is not a duplicate when the website matches an existing operator")
+    </div>
+    <p><input type="submit" value="Save" class="btn btn-primary" /></p>
+}

--- a/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
+++ b/Website/OCM.Web/Views/CountryOperators/Edit.cshtml
@@ -103,10 +103,13 @@
                             </div>
                         }
 
-                        <div class="custom-control custom-checkbox">
-                            @Html.CheckBoxFor(model => model.ConfirmWebsiteMatch, new { @class = "custom-control-input" })
-                            @Html.LabelFor(model => model.ConfirmWebsiteMatch, "Confirm this is not a duplicate when the website matches an existing operator", new { @class = "custom-control-label" })
-                        </div>
+                        @if (ViewBag.HasWebsiteMatch == true)
+                        {
+                            <div class="custom-control custom-checkbox">
+                                @Html.CheckBoxFor(model => model.ConfirmWebsiteMatch, new { @class = "custom-control-input" })
+                                @Html.LabelFor(model => model.ConfirmWebsiteMatch, "I reviewed the website match and this is a separate operator", new { @class = "custom-control-label" })
+                            </div>
+                        }
                     </div>
                 </div>
 


### PR DESCRIPTION
## What does this PR do?
Adds the country-operator create/edit workflow for Country Editors and Admins, with country-scoped authorization, duplicate-title protection, and create/update feedback.

Focused tests cover duplicate-normalization helpers.
Follow-up PRs can add regular-user proposals, review queues/notifications, and admin merge tooling.


## Manual test plan

- Sign in as a Country Editor and open `/countryoperators/edit`
- Add a country-specific operator and verify the ISO code is added to the saved title
- Edit the operator at `/countryoperators/edit/{id}` and verify the updated details and confirmation message
- Try an exact duplicate and verify creation is blocked
- Try a matching website and verify the confirmation warning
- Sign in as an Admin and verify operators can be created and edited for any country
- Sign in as a regular user and verify the operator-management page is not accessible

## Screenshots

**Adding an operator**
<img width="1792" height="1137" alt="Screen Shot 2026-08-27 at 11 15 16" src="https://github.com/user-attachments/assets/dd880f5b-831b-4f6e-b1f1-597457ee4d97" />

**Adding an operator with the same name**
<img width="1792" height="1137" alt="Screen Shot 2026-08-27 at 11 15 45" src="https://github.com/user-attachments/assets/26e549e9-4d1d-4dc6-a283-ac94d14dfd3c" />



Refs #256 